### PR TITLE
PROCESSING-3433: New serializer for MetadataType

### DIFF
--- a/src/main/java/com/piksel/sequoia/clientsdk/configuration/DefaultClientConfiguration.java
+++ b/src/main/java/com/piksel/sequoia/clientsdk/configuration/DefaultClientConfiguration.java
@@ -58,6 +58,8 @@ public class DefaultClientConfiguration {
                         .typeAdapter(new ForwardingListDeserializer()).build(),
                 TypeAdapter.builder().superClass(ForwardingList.class)
                         .typeAdapter(new ForwardingListSerializer()).build(),
+                TypeAdapter.builder().superClass(MetadataType.class)
+                        .typeAdapter(new MetadataTypeSerializer()).build(),
                 TypeAdapter.builder().superClass(MetadataLockFieldValue.class)
                         .typeAdapter(new MetadataLockFieldValueSerializer()).build(),
                 TypeAdapter.builder().superClass(MetadataLockFieldValue.class)

--- a/src/main/java/com/piksel/sequoia/clientsdk/resource/json/MetadataTypeSerializer.java
+++ b/src/main/java/com/piksel/sequoia/clientsdk/resource/json/MetadataTypeSerializer.java
@@ -1,0 +1,61 @@
+package com.piksel.sequoia.clientsdk.resource.json;
+
+/*-
+ * #%L
+ * Sequoia Java Client SDK
+ * %%
+ * Copyright (C) 2018 Piksel
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.piksel.sequoia.clientsdk.resource.MetadataType;
+
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+public class MetadataTypeSerializer implements JsonSerializer<MetadataType> {
+
+    @Override
+    public JsonElement serialize(MetadataType src, Type typeOfSrc, JsonSerializationContext context) {
+        if (isEmptyMetadataType(src)) {
+            return null;
+        }
+
+        JsonElement fields = context.serialize(src.getFields());
+
+        JsonObject metadataType = new JsonObject();
+        metadataType.add("fields", fields);
+        return metadataType;
+    }
+
+    private boolean isEmptyMetadataType(MetadataType metadataType) {
+        return  Objects.isNull(metadataType) ||
+                Objects.isNull(metadataType.getFields()) ||
+                metadataType.getFields().isEmpty() ||
+                (lockActionsIsEmpty(metadataType) && lockStatusesIsEmpty(metadataType));
+    }
+
+    private boolean lockStatusesIsEmpty(MetadataType metadataType) {
+        return Objects.isNull(metadataType.getLockStatuses()) || metadataType.getLockStatuses().getLockValues().isEmpty();
+    }
+
+    private boolean lockActionsIsEmpty(MetadataType metadataType) {
+        return Objects.isNull(metadataType.getLockActions()) || metadataType.getLockActions().getLockValues().isEmpty();
+    }
+}

--- a/src/test/java/com/piksel/sequoia/clientsdk/resource/ResourceTest.java
+++ b/src/test/java/com/piksel/sequoia/clientsdk/resource/ResourceTest.java
@@ -93,24 +93,29 @@ public class ResourceTest extends ModelResourceTestBase {
     @Test
     public void givenJsonWithEmptyMetadata_shouldGiveEmptyMetadata() throws JSONException {
         final String originalResourceJson = "{\"ref\":\"test:56b9bb7d8e4aa6e54b874844\",\"owner\":\"test\",\"metadata\":{}}";
-        final String expectedResourceJson = "{\"ref\":\"test:56b9bb7d8e4aa6e54b874844\",\"owner\":\"test\",\"metadata\":{\"fields\":{\"locks\":{},\"locking\":{}}}}";
+        final String expectedResourceJson = "{\"ref\":\"test:56b9bb7d8e4aa6e54b874844\",\"owner\":\"test\"}";
         Resource res = parse(originalResourceJson, Resource.class);
 
         assertNotNull(res.getMetadata());
         assertNotNull(res.getMetadata().getLockActions());
         assertNotNull(res.getMetadata().getLockStatuses());
+        assertEquals(0, res.getMetadata().getLockActions().getLockValues().size());
+        assertEquals(0, res.getMetadata().getLockStatuses().getLockValues().size());
+
         String responseJson = serialize(res);
         JSONAssert.assertEquals(expectedResourceJson, responseJson, JSONCompareMode.STRICT);
     }
 
     @Test
     public void givenJsonWithEmptyMetadataFields_shouldGiveEmptyMetadata() throws JSONException {
-        final String expectedResourceJson = "{\"ref\":\"test:56b9bb7d8e4aa6e54b874844\",\"owner\":\"test\",\"metadata\":{\"fields\":{}}}";
-        Resource res = parse(expectedResourceJson, Resource.class);
+        final String originalResourceJson = "{\"ref\":\"test:56b9bb7d8e4aa6e54b874844\",\"owner\":\"test\",\"metadata\":{\"fields\":{}}}";
+        final String expectedResourceJson = "{\"ref\":\"test:56b9bb7d8e4aa6e54b874844\",\"owner\":\"test\"}";
+        Resource res = parse(originalResourceJson, Resource.class);
 
         assertNotNull(res.getMetadata());
         assertNull(res.getMetadata().getLockActions());
         assertNull(res.getMetadata().getLockStatuses());
+
         String responseJson = serialize(res);
         JSONAssert.assertEquals(expectedResourceJson, responseJson, JSONCompareMode.STRICT);
     }
@@ -118,12 +123,13 @@ public class ResourceTest extends ModelResourceTestBase {
     @Test
     public void givenJsonWithInvalidMetadataFields_shouldGiveEmptyMetadata() throws JSONException {
         final String originalResourceJson = "{\"ref\":\"test:56b9bb7d8e4aa6e54b874844\",\"owner\":\"test\",\"metadata\":{\"fields\":{\"invalidField\":\"invalidVAlue\"}}}";
-        final String expectedResourceJson = "{\"ref\":\"test:56b9bb7d8e4aa6e54b874844\",\"owner\":\"test\",\"metadata\":{\"fields\":{}}}";
+        final String expectedResourceJson = "{\"ref\":\"test:56b9bb7d8e4aa6e54b874844\",\"owner\":\"test\"}";
         Resource res = parse(originalResourceJson, Resource.class);
 
         assertNotNull(res.getMetadata());
         assertNull(res.getMetadata().getLockActions());
         assertNull(res.getMetadata().getLockStatuses());
+
         String responseJson = serialize(res);
         JSONAssert.assertEquals(expectedResourceJson, responseJson, JSONCompareMode.STRICT);
     }


### PR DESCRIPTION
New serializer for MetadataType to avoid building the jsonObject when it's empty.

This PR prevents from serializing the Java object with a metadata field like:
```
"metadata": {}
```
or 
```
"metadata": {
  "fields": {}
}
```
or
```
"metadata": {
  "fields": {
    "locks": {},
    "locking": {}
  }
}
```